### PR TITLE
CDAP-15838 Decompress-action plugin validation - package rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
@@ -161,7 +161,7 @@
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>
             <!--Only @Plugin classes in the export packages will be included as plugin-->
-            <_exportcontents>io.cdap.plugin.*</_exportcontents>
+            <_exportcontents>io.cdap.plugin.decompress.action.*</_exportcontents>
           </instructions>
         </configuration>
         <executions>
@@ -179,8 +179,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/decompress/action/DecompressAction.java
+++ b/src/main/java/io/cdap/plugin/decompress/action/DecompressAction.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.decompress.action;
 
 
 import com.google.common.base.Strings;

--- a/src/test/java/io/cdap/plugin/decompress/action/DecompressActionTest.java
+++ b/src/test/java/io/cdap/plugin/decompress/action/DecompressActionTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin;
+package io.cdap.plugin.decompress.action;
 
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import org.junit.ClassRule;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15838

In scope of this PR:
- migrated to CDAP core 6.1.0-SNAPSHOT
- renamed packages to io.cdap.plugin.decompress.action